### PR TITLE
README - Add section about how to enter a dev shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .butler-*/
 dist-newstyle
+.vscode

--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@ Container usage:
 ```ShellSession
 podman run -p 8080:8080 -v butler-data:/var/lib/butler ghcr.io/tristancacqueray/haskell-butler:term-latest
 ```
+
+## Hack on haskell-butler
+
+First you can configure the project [cachix](https://cachix.org) binary cache with this command: `nix shell nixpkgs#cachix --command cachix use change-metrics`.
+
+Then, enter a dev shell via Nix with: `nix develop`.


### PR DESCRIPTION
Just added few lines about how to start a dev shell. I saw in the GHA config that there is a mention of change-metrics's cachix account so I guess that the one that could be set in the nix config.