### PR TITLE
Add data/* to extra-source-files

### DIFF
--- a/butler.cabal
+++ b/butler.cabal
@@ -18,6 +18,8 @@ license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
     CHANGELOG.md
+    data/haskell-butler-logo.svg
+    data/ws.js
 
 source-repository head
   type: git


### PR DESCRIPTION
This makes those files to be part of the sdist
```
[nix(butler)] cabal sdist -l | grep -i data                                                
./data/haskell-butler-logo.svg                                                             
./data/ws.js 
```